### PR TITLE
Add Vercel and Supabase deployment badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 An Offer seeker powered by GPT.
 
 [![](https://dcbadge.limes.pink/api/server/X24GHUwtHW?style=flat)](https://discord.gg/X24GHUwtHW?style=flat)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyuan99/offerplus)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An Offer seeker powered by GPT.
 
 [![](https://dcbadge.limes.pink/api/server/X24GHUwtHW?style=flat)](https://discord.gg/X24GHUwtHW?style=flat)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyuan99/offerplus)
+[![Powered by Supabase](https://img.shields.io/badge/Powered%20by-Supabase-3ecf8e?style=flat&logo=supabase)](https://supabase.com)
 
 ## Table of Contents
 


### PR DESCRIPTION
## Description
Added two deployment and infrastructure badges to the README.md file:
- Vercel deployment button badge with direct clone-to-deploy link
- Supabase powered badge to highlight the backend infrastructure

## Motivation and Context
These badges improve project visibility by:
1. Making it easier for users to deploy the project directly to Vercel with a single click
2. Acknowledging Supabase as a key infrastructure dependency
3. Following common practices in open-source projects to showcase deployment options and tech stack

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
N/A - Badge links are static markdown/HTML and can be visually verified in the rendered README.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

https://claude.ai/code/session_01P9Nte8xvnjDhz4Fx6zeArw