### PR TITLE
feat: implement resume text extraction (process-resume)

### DIFF
--- a/frontend/src/pages/JobGPT.tsx
+++ b/frontend/src/pages/JobGPT.tsx
@@ -22,6 +22,7 @@ interface ModelOption {
 export function JobGPT() {
   const [state, setState] = useState<JobGPTState>(initialState);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [resumeStatus, setResumeStatus] = useState<string | null>(null);
   const [companyName, setCompanyName] = useState('');
   const [userBackground, setUserBackground] = useState('');
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([
@@ -126,15 +127,21 @@ export function JobGPT() {
     }
 
     setState({ ...state, isLoading: true, error: null });
+    setResumeStatus(null);
 
     try {
       const response = await jobgptService.uploadResume(selectedFile);
-      if (response.file_url) {
-        // Handle successful upload
+      if (response.success) {
         setState({ ...state, isLoading: false });
+        setResumeStatus(
+          `Resume processed (${response.textLength ?? 0} characters extracted${response.truncated ? ', truncated' : ''}).`
+        );
+      } else {
+        setState({ ...state, isLoading: false, error: response.error ?? 'Failed to process resume' });
       }
-    } catch (error: unknown) {
-      setState({ ...state, isLoading: false, error: error.message });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to process resume';
+      setState({ ...state, isLoading: false, error: message });
     }
   };
 
@@ -150,6 +157,40 @@ export function JobGPT() {
           <p className="mt-2 text-gray-600 max-w-3xl">
             AI-powered assistant to help you craft compelling cover letters, improve your resume, and prepare for interviews.
           </p>
+        </div>
+
+        {/* Resume Upload */}
+        <div className="bg-white rounded-lg shadow p-6 mb-6">
+          <div className="flex items-center gap-2 mb-4">
+            <FileText className="h-5 w-5 text-[#861F41]" />
+            <h2 className="text-lg font-semibold text-gray-900">Resume (optional)</h2>
+          </div>
+          <p className="text-sm text-gray-600 mb-4">
+            Upload your resume so JobGPT can pull real context into generated answers.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+            <input
+              type="file"
+              accept=".pdf,.docx"
+              onChange={handleFileChange}
+              disabled={state.isLoading}
+              className="text-sm text-gray-600"
+            />
+            <button
+              onClick={handleFileUpload}
+              disabled={state.isLoading || !selectedFile}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+            >
+              <Upload className="h-4 w-4" />
+              Upload
+            </button>
+          </div>
+          {resumeStatus && (
+            <div className="flex items-center gap-2 mt-3 text-sm text-green-700">
+              <ThumbsUp className="h-4 w-4" />
+              {resumeStatus}
+            </div>
+          )}
         </div>
 
         {/* Mode Selection */}

--- a/frontend/src/services/jobgptService.ts
+++ b/frontend/src/services/jobgptService.ts
@@ -5,9 +5,10 @@ import { AIModelManager, AIModelError } from '../lib/aiModelAdapters';
 
 interface ResumeUploadResponse {
   success: boolean;
-  filePath?: string;
-  message?: string;
-  // Add other response properties as needed
+  text?: string;
+  textLength?: number;
+  truncated?: boolean;
+  error?: string;
 }
 
 export const jobgptService = {
@@ -130,31 +131,34 @@ export const jobgptService = {
     }
   },
 
-  uploadResume: async (file: File) => {
+  uploadResume: async (file: File): Promise<ResumeUploadResponse> => {
     try {
-      // First upload the file to Supabase Storage
+      const { data: { user }, error: userError } = await supabase.auth.getUser();
+      if (userError || !user) throw new Error('Please log in to upload a resume');
+
+      // Files must live under `<user.id>/...` to satisfy the resumes bucket's RLS policies
       const fileExt = file.name.split('.').pop();
       const fileName = `${Math.random().toString(36).substring(2)}.${fileExt}`;
-      const filePath = `resumes/${fileName}`;
-      
+      const filePath = `${user.id}/${fileName}`;
+
       const { error: uploadError } = await supabase.storage
         .from('resumes')
         .upload(filePath, file);
-      
+
       if (uploadError) throw uploadError;
-      
+
       // Get the public URL
       const { data: { publicUrl } } = supabase.storage
         .from('resumes')
         .getPublicUrl(filePath);
-      
-      // Call the Edge Function to process the resume
+
+      // Call the Edge Function to extract and persist the resume's text
       const { data, error } = await supabase.functions.invoke('process-resume', {
         body: { filePath: publicUrl }
       });
-      
+
       if (error) throw error;
-      return data;
+      return data as ResumeUploadResponse;
     } catch (error) {
       console.error('Error uploading resume:', error);
       throw error;

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,4 @@
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};

--- a/supabase/functions/process-resume/index.ts
+++ b/supabase/functions/process-resume/index.ts
@@ -1,0 +1,133 @@
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { extractText, getDocumentProxy } from 'npm:unpdf@0.12.1';
+import mammoth from 'npm:mammoth@1.8.0';
+import { Buffer } from 'node:buffer';
+import { corsHeaders } from '../_shared/cors.ts';
+
+const MAX_TEXT_LENGTH = 20000;
+const MAX_FILE_BYTES = 5 * 1024 * 1024; // matches the frontend's upload size limit
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return jsonResponse({ success: false, error: 'Missing Authorization header' }, 401);
+    }
+
+    const { filePath } = await req.json();
+    if (!filePath || typeof filePath !== 'string') {
+      return jsonResponse({ success: false, error: 'filePath is required' }, 400);
+    }
+
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } },
+    );
+
+    const { data: { user }, error: userError } = await supabaseClient.auth.getUser();
+    if (userError || !user) {
+      return jsonResponse({ success: false, error: 'Not authenticated' }, 401);
+    }
+
+    const fileResponse = await fetch(filePath);
+    if (!fileResponse.ok) {
+      return jsonResponse(
+        { success: false, error: `Could not download resume (HTTP ${fileResponse.status})` },
+        400,
+      );
+    }
+
+    const declaredLength = Number(fileResponse.headers.get('content-length') ?? '0');
+    if (declaredLength > MAX_FILE_BYTES) {
+      return jsonResponse({ success: false, error: 'Resume file is too large to process' }, 400);
+    }
+
+    const bytes = new Uint8Array(await fileResponse.arrayBuffer());
+    if (bytes.byteLength > MAX_FILE_BYTES) {
+      return jsonResponse({ success: false, error: 'Resume file is too large to process' }, 400);
+    }
+
+    const extension = filePath.split('.').pop()?.toLowerCase().split(/[?#]/)[0] ?? '';
+
+    let resumeText: string;
+    try {
+      resumeText = await extractResumeText(bytes, extension);
+    } catch (extractError) {
+      console.error('Resume text extraction failed:', extractError);
+      return jsonResponse(
+        {
+          success: false,
+          error: extractError instanceof Error ? extractError.message : 'Failed to extract resume text',
+        },
+        422,
+      );
+    }
+
+    if (!resumeText.trim()) {
+      return jsonResponse(
+        { success: false, error: 'No extractable text found in this resume' },
+        422,
+      );
+    }
+
+    const truncated = resumeText.length > MAX_TEXT_LENGTH;
+    const text = truncated ? resumeText.slice(0, MAX_TEXT_LENGTH) : resumeText;
+
+    const { error: updateError } = await supabaseClient
+      .from('profiles')
+      .update({ resume_text: text, resume_text_updated_at: new Date().toISOString() })
+      .eq('id', user.id);
+
+    if (updateError) {
+      console.error('Failed to persist resume text:', updateError);
+      return jsonResponse({ success: false, error: 'Failed to save extracted resume text' }, 500);
+    }
+
+    return jsonResponse({ success: true, text, textLength: text.length, truncated });
+  } catch (error) {
+    console.error('process-resume error:', error);
+    return jsonResponse(
+      { success: false, error: error instanceof Error ? error.message : 'Unexpected error' },
+      500,
+    );
+  }
+});
+
+async function extractResumeText(bytes: Uint8Array, extension: string): Promise<string> {
+  if (extension === 'pdf') {
+    const pdf = await getDocumentProxy(bytes);
+    const { text } = await extractText(pdf, { mergePages: true });
+    return normalizeWhitespace(text);
+  }
+
+  if (extension === 'docx') {
+    const { value } = await mammoth.extractRawText({ buffer: Buffer.from(bytes) });
+    return normalizeWhitespace(value);
+  }
+
+  if (extension === 'doc') {
+    throw new Error('Legacy .doc files are not supported yet — please upload a PDF or DOCX resume.');
+  }
+
+  throw new Error(`Unsupported resume file type: .${extension || 'unknown'}`);
+}
+
+function normalizeWhitespace(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/migrations/20260711000000_add_resume_text_to_profiles.sql
+++ b/supabase/migrations/20260711000000_add_resume_text_to_profiles.sql
@@ -1,0 +1,6 @@
+-- Store text extracted from a user's uploaded resume by the process-resume
+-- Edge Function, so it can be reused for tailored generation and fit scoring
+-- without re-parsing the file on every request.
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS resume_text text,
+  ADD COLUMN IF NOT EXISTS resume_text_updated_at timestamptz;


### PR DESCRIPTION
## Summary
- Closes #149.
- Implements the `process-resume` Supabase Edge Function (`supabase/functions/process-resume/index.ts`): downloads an uploaded resume (PDF or DOCX), extracts its text (`unpdf` for PDF, `mammoth` for DOCX), and persists it to a new `profiles.resume_text` column (`supabase/migrations/20260711000000_add_resume_text_to_profiles.sql`) so it's available for tailored generation and future fit scoring without re-parsing the file each time.
- Fixes a latent bug in `frontend/src/services/jobgptService.ts:uploadResume` — it stored files at `resumes/<file>` instead of `<user.id>/<file>`, which violates the `resumes` storage bucket's RLS insert policy (`(storage.foldername(name))[1] = auth.uid()`). The upload would have failed before ever reaching the Edge Function.
- Wires up the resume upload UI in `frontend/src/pages/JobGPT.tsx` (the file input and handlers already existed but were never rendered) and shows the extraction result/error to the user.

## Notes for reviewers
- Requires `supabase db push` (for the migration) and `supabase functions deploy process-resume` to take effect against a live project — this repo has no CI step that deploys Edge Functions or migrations automatically.
- Legacy `.doc` (binary Word format) resumes are explicitly unsupported and return a clear error asking for PDF/DOCX — full binary `.doc` parsing isn't practical in the Deno edge runtime.
- `frontend/src/pages/JobGPT.tsx` verified with `npx tsc --noEmit` (0 errors). The new Edge Function is plain Deno/TypeScript; I don't have a local Deno runtime in this environment to execute it, so it hasn't been runtime-tested — recommend a quick `supabase functions serve process-resume` smoke test before merging.

## Test plan
- [x] `npx tsc --noEmit` passes for the frontend
- [ ] `supabase db push` + `supabase functions deploy process-resume` against a dev project, then manually upload a PDF and DOCX resume via JobGPT and confirm `profiles.resume_text` populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)