### PR TITLE
fix: remove failing RLS re-enable statement from resumes bucket migration

### DIFF
--- a/supabase/migrations/20240124_create_resumes_bucket.sql
+++ b/supabase/migrations/20240124_create_resumes_bucket.sql
@@ -35,5 +35,7 @@ using (
     and (storage.foldername(name))[1] = auth.uid()::text
 );
 
--- Enable RLS
-alter table storage.objects enable row level security;
+-- Note: RLS is already enabled on storage.objects by default in every Supabase
+-- project. Re-enabling it here fails with "must be owner of table objects"
+-- because storage.objects is owned by supabase_storage_admin, not the role
+-- migrations run as.


### PR DESCRIPTION
## Summary
- Reported error: `ERROR: must be owner of table objects (SQLSTATE 42501)` on `alter table storage.objects enable row level security`.
- `storage.objects` is owned by `supabase_storage_admin`, not the role migrations run as, so this statement can never succeed regardless of environment. It's also unnecessary — RLS is already enabled on `storage.objects` by default in every Supabase project.
- Removes the statement from `supabase/migrations/20240124_create_resumes_bucket.sql` (replaced with an explanatory comment) so the migration batch no longer gets stuck on it.

## Test plan
- [x] Confirmed no other migration alters RLS on a Supabase-system-owned table (`storage.*`, `auth.*`, `realtime.*`).
- [ ] Re-run migrations (`supabase db push` / `supabase migration up`) and confirm they complete past this statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)