### PR TITLE
chore: add dev server launch configuration

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "frontend", "run", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "supabase-studio",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["supabase", "start"],
+      "port": 54323
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/launch.json` defining the two local dev servers detected in this project:
  - `frontend` — `npm --prefix frontend run dev` (Vite, port 5173), the main app
  - `supabase-studio` — `npx supabase start` (local Supabase stack, Studio UI on port 54323; requires Docker), only needed for local-DB development instead of the remote project

## Test plan
- [x] Confirmed `npm --prefix frontend run dev` starts Vite on port 5173
- [x] Confirmed `npx supabase --version` resolves via npx (CLI not globally installed, but fetchable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)