### PR TITLE
fix: add missing h1b_applications table migration

### DIFF
--- a/supabase/migrations/20240123_create_h1b_applications_table.sql
+++ b/supabase/migrations/20240123_create_h1b_applications_table.sql
@@ -1,0 +1,47 @@
+-- Creates the h1b_applications table expected by the statistics/filter/
+-- performance migrations that follow (20240125-20240127). This table was
+-- previously only ever created ad hoc by manually pasting the SQL printed
+-- by h1b/upload_to_supabase.py's create_h1b_table() helper into the
+-- Supabase dashboard, so it was never part of the tracked migration
+-- history -- running migrations fresh (e.g. `supabase db reset`, or
+-- against a new project) failed with "relation h1b_applications does not
+-- exist" once it reached the first CREATE INDEX statement.
+--
+-- Schema matches h1b/upload_to_supabase.py exactly. Note this table is
+-- later dropped by 20250509_cleanup_legacy_tables.sql, so this migration
+-- only affects whether the migration chain completes -- it does not
+-- change the final schema state.
+
+CREATE TABLE IF NOT EXISTS h1b_applications (
+    id BIGSERIAL PRIMARY KEY,
+    case_number TEXT UNIQUE NOT NULL,
+    case_status TEXT,
+    received_date TIMESTAMPTZ,
+    decision_date TIMESTAMPTZ,
+    visa_class TEXT,
+    job_title TEXT,
+    soc_code TEXT,
+    soc_title TEXT,
+    full_time_position TEXT,
+    begin_date TIMESTAMPTZ,
+    end_date TIMESTAMPTZ,
+    employer_name TEXT,
+    employer_city TEXT,
+    employer_state TEXT,
+    employer_postal_code TEXT,
+    worksite_city TEXT,
+    worksite_state TEXT,
+    worksite_postal_code TEXT,
+    wage_rate_of_pay_from NUMERIC,
+    wage_rate_of_pay_to NUMERIC,
+    wage_unit_of_pay TEXT,
+    prevailing_wage NUMERIC,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE h1b_applications ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow public read access" ON h1b_applications;
+CREATE POLICY "Allow public read access" ON h1b_applications
+    FOR SELECT USING (true);


### PR DESCRIPTION
## Summary
- Reported error: `ERROR: relation "h1b_applications" does not exist (SQLSTATE 42P01)`, failing on the first `CREATE INDEX` statement in `supabase/migrations/20240125_create_h1b_statistics_functions_updated.sql`.
- Root cause: no Supabase migration ever creates `h1b_applications`. It was only ever created ad hoc — `h1b/upload_to_supabase.py`'s `create_h1b_table()` helper just *prints* a `CREATE TABLE` statement and tells the user to paste it into the Supabase dashboard SQL editor manually. That works once, against one already-set-up project, but running the tracked migrations fresh (new project, or `supabase db reset`) fails as soon as `20240125`–`20240127` try to index/query a table that was never created via migration.
- Adds `supabase/migrations/20240123_create_h1b_applications_table.sql`, ordered before the statistics/filter/performance migrations, with a schema matching `upload_to_supabase.py`'s `CREATE TABLE` exactly (so it matches whatever's already live in production).

## Note for reviewers
- `supabase/migrations/20250509_cleanup_legacy_tables.sql` already `DROP TABLE IF EXISTS h1b_applications` later in the chain (bundled in with Django/tracks legacy table cleanup). I left that alone — it's out of scope for this fix, and I'm not certain whether sweeping up `h1b_applications` there was intentional or accidental, since the H1B viewer UI (`H1BViewerNative.tsx`, `h1bStatisticsService.ts`, etc.) still appears to be an active feature. Worth a separate look if the H1B viewer is supposed to still work against this table. This PR only makes the migration chain itself complete without erroring — it doesn't change the final schema state.

## Test plan
- [ ] Run migrations end-to-end (`supabase db push` / `supabase migration up`) against a fresh project and confirm they complete past the previously-failing statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)