### PR TITLE
fix: add accessible labels to DocumentManager form controls

### DIFF
--- a/frontend/src/components/DocumentManager.tsx
+++ b/frontend/src/components/DocumentManager.tsx
@@ -88,7 +88,11 @@ export function DocumentManager() {
 
       <div className="mb-6 p-4 bg-gray-50 rounded-lg border border-gray-200">
         <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+          <label htmlFor="document-type" className="sr-only">
+            Document type
+          </label>
           <select
+            id="document-type"
             value={selectedType}
             onChange={(e) => setSelectedType(e.target.value as DocumentType)}
             disabled={isUploading}
@@ -100,7 +104,11 @@ export function DocumentManager() {
               </option>
             ))}
           </select>
+          <label htmlFor="document-file" className="sr-only">
+            Choose a file to upload
+          </label>
           <input
+            id="document-file"
             type="file"
             onChange={handleFileChange}
             disabled={isUploading}


### PR DESCRIPTION
## Summary
- The document-type `<select>` and file `<input>` in `DocumentManager.tsx` (#152) had no associated `<label>` — flagged during a React best-practices review.
- Adds visually-hidden (`sr-only`) `<label>`s tied via `htmlFor`/`id` to each control so screen readers announce them, without changing the visual layout.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Diff is purely additive (2 labels + 2 ids), no visual/behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)